### PR TITLE
gems: bump keccak to 1.3.0

### DIFF
--- a/adequate_crypto_address.gemspec
+++ b/adequate_crypto_address.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'base58', '~> 0.2.3'
-  spec.add_dependency 'digest-sha3', '~> 1.1.0'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_dependency 'base58', '~> 0.2'
+  spec.add_dependency 'keccak', '~> 1.3'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.10'
 end

--- a/lib/adequate_crypto_address/eth.rb
+++ b/lib/adequate_crypto_address/eth.rb
@@ -76,7 +76,7 @@ module AdequateCryptoAddress
     end
 
     def keccak256(x)
-      Digest::SHA3.new(256).digest(x)
+      Digest::Keccak.new(256).digest(x)
     end
   end
   Ethereum = Eth


### PR DESCRIPTION
replaces unmaintained digest-sha3 with keccak for ruby 2.3 and later
* ref https://github.com/q9f/keccak.rb/pull/16